### PR TITLE
Fix for non owner/user names

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,9 +17,11 @@ module.exports = function gitSource(input) {
     }
 
     let splits = input.split(":");
+
     if (parsed.protocol === "file" || parsed.protocol === "ssh") {
         let source = splits[0]
           , target = splits[1]
+          , targetSplits = null
           ;
 
         if (~source.indexOf("@")) {
@@ -36,11 +38,16 @@ module.exports = function gitSource(input) {
             return parsed;
         }
 
+        targetSplits = target.split("/");
+        if (source !== "gist" && targetSplits.length !== 2) {
+            return parsed;
+        }
+
         if (~PROVIDERS_LIST.indexOf(source)) {
             return gitSource(`${PROVIDERS[source]}/${target}`);
         }
 
-        return gitSource();
+        return parsed;
     }
 
     return parsed;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-source",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Parse and stringify git urls in a friendly way.",
   "main": "lib/index.js",
   "directories": {

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,7 @@ tester.describe("git-source", test => {
     test.it("takes GitHub as default", () => {
         test.expect(gitSource("owner/repo").resource).toBe("github.com");
     });
+
     test.it("custom sources", () => {
         test.expect(gitSource("gist:hash").resource).toBe("gist.github.com");
         test.expect(gitSource("gist:ionicabizau/hash").resource).toBe("gist.github.com");
@@ -13,13 +14,17 @@ tester.describe("git-source", test => {
         test.expect(gitSource("file:owner/repo").protocol).toBe("file");
         test.expect(gitSource("./path/to/foo").protocol).toBe("file");
         test.expect(gitSource("/absolute/path").protocol).toBe("file");
+        test.expect(gitSource("foo").protocol).toBe("file");
     });
+
     test.it("handle commit-ish values", () => {
         test.expect(gitSource("foo/bar#foo").hash).toBe("foo");
     });
+
     test.it("handle full paths", () => {
         test.expect(gitSource("git@github.com:IonicaBizau/node-git-url-parse.git").source).toBe("github.com");
     });
+
     test.should("stringify correctly", () => {
         test.expect(gitSource("owner/repo").toString()).toBe("https://github.com/owner/repo");
         test.expect(gitSource("owner/repo").toString("ssh")).toBe("git@github.com:owner/repo.git");


### PR DESCRIPTION
`gitSource("foo")` should return `protocol:file` and not being interpreted as GitHub path.
